### PR TITLE
US210 - QA ready, CSS integration for create_term.phtml and more

### DIFF
--- a/Source/JavaScript/Admin/create_term.js
+++ b/Source/JavaScript/Admin/create_term.js
@@ -1,3 +1,13 @@
+/**********  JQuery Includes are Scary  **********/
+$.getScript("../../JavaScript/Utility/input_validation.js");
+
+
+/**********  Object Initialization  **********/
+$("#startDate").datepicker();
+$("#endDate").datepicker();
+$("#dueDate").datepicker();
+
+
 /**********  New Methods for Built in Objects  **********/
 Date.prototype.toPaddedLocaleDateString = function() {
     var day = this.getDate().toString();
@@ -10,153 +20,261 @@ Date.prototype.toPaddedLocaleDateString = function() {
 };
 
 
-$(document).ready( function() {
-    /**********  JQuery Includes are Scary  **********/
-    $.getScript("../../JavaScript/Utility/input_validation.js");
-
-
-    /**********  Global Variables  **********/
-    var termName = $("#termName");
-    var startInput = $("#startDate");
-    var endInput = $("#endDate");
-    var dueInput = $("#dueDate");
-    var statsStartEndText = $("#statsStartToEnd");
-    var statsDueStartText = $("#statsDueToStart");
-    var submitButton = $("#submitButton");
-    var resetButton = $("#resetButton");
-    
-	/**********  Object Initialization  **********/
-    startInput.datepicker();
-    endInput.datepicker();
-    dueInput.datepicker();
-
-
-	/**********  Functions  **********/
-    //  function to validate input before enabling the submit button
-    function validateInput() {
-        if (termName.val().length > 0 &&
-                dateIsValid(startInput.val()) &&
-                dateIsValid(endInput.val()) &&
-                dateIsValid(dueInput.val())) {
-            submitButton.prop("disabled", false);
-        } else {
-			submitButton.prop("disabled", true);
-		}
+/**********  Functions  **********/
+//  function to validate input before enabling the submit button
+function validateInput() {
+    if ($("#termName").val().length > 0 &&
+            dateIsValid($("#startDate").val()) &&
+            dateIsValid($("#endDate").val()) &&
+            dateIsValid($("#dueDate").val())) {
+        $("#submitButton").prop("disabled", false);
+    } else {
+        $("#submitButton").prop("disabled", true);
     }
+}
 
-    //  function to update statistics of term
-    function updateStats() {
-        //  horrifyingly large ammount of variables required for calculations
+//  function to update term information
+function updateInfo() {
+    //  Check if enough data is present to calculate info
+    if (dateIsValid($("#startDate").val()) && (dateIsValid($("#endDate").val()) || dateIsValid($("#dueDate").val()))) {
+        //  variables and constants
         var msecs_to_day = 1000*60*60*24;
         var day_names = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-        var startDate = new Date(startInput.val());
-        var endDate = new Date(endInput.val());
-        var startMsec = startDate.getTime();
-        var endMsec = endDate.getTime();
-        var dueMsec = (new Date(dueInput.val())).getTime();
-        var start_to_end_days = Math.ceil((endMsec - startMsec) / msecs_to_day);
-        var start_to_end_weeks = Math.ceil(start_to_end_days / 7);
-        var due_to_start_days = Math.ceil((startMsec - dueMsec) / msecs_to_day);
+        
+        //  check if enough data is present to calculate the term duration
+        if (dateIsValid($("#startDate").val()) && dateIsValid($("#endDate").val())) {
+            //  variables and calculation for term duration
+            var startDate = new Date($("#startDate").val());
+            var endDate = new Date($("#endDate").val());
+            var startMsec = startDate.getTime();
+            var endMsec = endDate.getTime();
+            var start_to_end_days = Math.ceil((endMsec - startMsec) / msecs_to_day);
+            var start_to_end_weeks = Math.ceil(start_to_end_days / 7);
 
-        //  calculates term duration
-        if (dateIsValid(startInput.val()) && dateIsValid(endInput.val())) {
-            statsStartEndText.text("Term Duration: ~" + start_to_end_weeks + " weeks (" + start_to_end_days + " days), " + day_names[startDate.getDay()] + " to " + day_names[endDate.getDay()]);
+            //  set the info for term duration and display it
+            $("#statsStartToEnd1").text(start_to_end_weeks + " weeks (" + start_to_end_days + " days)");
+            $("#statsStartToEnd2").text(day_names[startDate.getDay()] + " to " + day_names[endDate.getDay()]);
+            $("#termDuration").show();
         } else {
-            statsStartEndText.text("Term Duration: UNKNOWN");
+            //  not enough data, hide the info for term duration
+            $("#termDuration").hide();
+            $("#statsStartToEnd1").text("");
+            $("#statsStartToEnd2").text("");
         }
 
-        //  calculates time between due date and start of term
-        if (dateIsValid(startInput.val()) && dateIsValid(dueInput.val())) {
-            statsDueStartText.text("Due Date: " + due_to_start_days + " days before start");
+        //  check if enough data is present to calculate the due date offset
+        if (dateIsValid($("#startDate").val()) && dateIsValid($("#dueDate").val())) {
+            //  variables and calculation for due date offset
+            var startDate = new Date($("#startDate").val());
+            var startMsec = startDate.getTime();
+            var dueMsec = (new Date($("#dueDate").val())).getTime();
+            var due_to_start_days = Math.ceil((startMsec - dueMsec) / msecs_to_day);
+
+            //  set the info for the term duration and display it
+            $("#statsDueToStart").text(due_to_start_days + " days before start");
+            $("#dueOffset").show();
         } else {
-            statsDueStartText.text("Due Date: UNKNOWN");
+            //  not enough data, hide the info for due date offset
+            $("#dueOffset").hide();
+            $("#statsDueToStart").text("");
         }
+        
+        //  enough data for info, hide the warning
+        $("#termInfoWarning").hide();
+    } else {
+        //  not enough data for info, hide all info and show the warning
+        $("#termDuration").hide();
+        $("#dueOffset").hide();
+        $("#termInfoWarning").show();
+    }
+}
+
+
+/**********  Define Handlers  **********/
+//  change handler for termName
+$("#termName").change( function() {
+    if ($(this).val().length > 0) {
+        $("#nameGroup").removeClass("has-error");
+        $("#nameGroup").addClass("has-success");
+    } else {
+        $("#nameGroup").removeClass("has-success");
+        $("#nameGroup").addClass("has-error");
+    }
+    validateInput();
+});
+
+//  click handler for term name clear button
+$("#termNameClear").click( function() {
+    $("#termName").val("");
+    $("#termName").trigger("change");
+});
+
+//  change handler for start date input
+$("#startDate").change( function() {
+    if (dateIsValid($(this).val())) {
+        //  variables
+        var currentStart = $(this).datepicker("getDate");
+        var defaultEnd = new Date(currentStart);
+        var endMin = new Date(currentStart);
+        var defaultDue = new Date(currentStart);
+        var dueMax = new Date(currentStart);
+
+        //  calculate default dates for end and due dates
+        defaultEnd.setDate(currentStart.getDate() + 1);
+        endMin.setDate(currentStart.getDate() + 1);
+        defaultDue.setDate(currentStart.getDate() - 1);
+        dueMax.setDate(currentStart.getDate() - 1);
+
+        //  enable end date, set default date and min date
+        $("#endDate").datepicker("option", {
+            defaultDate: defaultEnd,
+            minDate: endMin,
+            disabled: false
+        });
+        //enable due date, set default date and max date
+        $("#dueDate").datepicker("option", {
+            defaultDate: defaultDue,
+            maxDate: dueMax,
+            disabled: false
+        });
+     
+        //  update objects
+        $("#startGroup").removeClass("has-error");
+        $("#startGroup").addClass("has-success");
+        $("#autofillButton").prop("disabled", false);
+    } else {
+        $("#startGroup").removeClass("has-success");
+        $("#startGroup").addClass("has-error");
+        $("#endDate").prop("disabled", true);
+        $("#dueDate").prop("disabled", true);
+        $("#autofillButton").prop("disabled", true);
     }
 
+    updateInfo();
+    validateInput();
+});
 
-	/**********  Define Handlers  **********/
-	//  change handler for termName
-    termName.change( function() {
-        if ($(this).val().length > 0) {
-            $(this).removeClass("invalidInput");
-        } else {
-            $(this).addClass("invalidInput");
-        }
-		validateInput();
-    });
+//  click handler for start date clear button
+$("#startDateClear").click( function() {
+    $("#startDate").val("");
+    $("#startDate").trigger("change");
+    $("#endDateClear").trigger("click");
+    $("#dueDateClear").trigger("click");
+});
 
-    //  change handler for startDate
-    startInput.change( function() {
-        if (dateIsValid($(this).val())) {
-            //  variables
-            var currentStart = $(this).datepicker("getDate");
-            var defaultEnd = new Date(currentStart);
-            var endMin = new Date(currentStart);
-            var defaultDue = new Date(currentStart);
-            var dueMax = new Date(currentStart);
+//  change handler for end date input
+$("#endDate").change( function() {
+    if (dateIsValid($(this).val())) {
+        $("#endGroup").removeClass("has-error");
+        $("#endGroup").addClass("has-success");
+    } else {
+        $("#endGroup").removeClass("has-success");
+        $("#endGroup").addClass("has-error");
+    }
+    updateInfo();
+    validateInput();
+});
 
-            //  calculate default dates for end and due dates
-            defaultEnd.setDate(currentStart.getDate() + 76);
-            endMin.setDate(currentStart.getDate() + 1);
-            defaultDue.setDate(currentStart.getDate() - 7);
-            dueMax.setDate(currentStart.getDate() - 1);
+//  click handler for end date clear button
+$("#endDateClear").click( function() {
+    $("#endDate").val("");
+    $("#endDate").trigger("change");
+    
+    if (dateIsValid($("#startDate").val())) {
+        var currentStart = $("#startDate").datepicker("getDate");
+        var defaultEnd = new Date(currentStart);
 
-            //  enable end date, set default date and min date
-            endInput.datepicker("option", {
-                defaultDate: defaultEnd,
-                minDate: endMin,
-                disabled: false
-            });
-            //enable due date, set default date and max date
-            endInput.val(defaultEnd.toPaddedLocaleDateString());
-            dueInput.datepicker("option", {
-                defaultDate: defaultDue,
-                maxDate: dueMax,
-                disabled: false
-            });
-            dueInput.val(defaultDue.toPaddedLocaleDateString());
-         
-            //  update objects
-            $(this).removeClass("invalidInput");
-            endInput.trigger("change");
-            dueInput.trigger("change");
-        } else {
-            $(this).addClass("invalidInput");
-        }
-		updateStats();
-		validateInput();
-    });
+        //  calculate default dates for end and due dates
+        defaultEnd.setDate(currentStart.getDate() + 1);
 
-    //  change handler for endDate
-    endInput.change( function() {
-        if (dateIsValid($(this).val())) {
-            $(this).removeClass("invalidInput");
-        } else {
-            $(this).addClasS("invalidInput");
-        }
-		updateStats();
-        validateInput();
-    });
+        //  enable end date, set default date and min date
+        $("#endDate").datepicker("option", {
+            defaultDate: defaultEnd,
+        });
+    }
+});
 
-    // change handler for dueDate
-    dueInput.change( function() {
-        if (dateIsValid($(this).val())) {
-            $(this).removeClass("invalidInput");
-        } else {
-            $(this).addClass("invalidInput");
-        }
-		updateStats();
-        validateInput();
-    });
+// change handler for due date input
+$("#dueDate").change( function() {
+    if (dateIsValid($(this).val())) {
+        $("#dueGroup").removeClass("has-error");
+        $("#dueGroup").addClass("has-success");
+    } else {
+        $("#dueGroup").removeClass("has-success");
+        $("#dueGroup").addClass("has-error");
+    }
+    updateInfo();
+    validateInput();
+});
 
-	//  click handler for reset button
-    resetButton.click( function() {
-        endInput.prop("disabled", true);
-        dueInput.prop("disabled", true);
-        termName.addClass("invalidInput");
-        startInput.addClass("invalidInput");
-        endInput.addClass("invalidInput");
-        dueInput.addClass("invalidInput");
-		submitButton.prop("disabled", true);
-    });
+//  click handler for due date clear button
+$("#dueDateClear").click( function() {
+    $("#dueDate").val("");
+    $("#dueDate").trigger("change");
+    
+    if (dateIsValid($("#startDate").val())) {
+        var currentStart = $("#startDate").datepicker("getDate");
+        var defaultDue = new Date(currentStart);
+
+        //  calculate default dates for end and due dates
+        defaultDue.setDate(currentStart.getDate() - 1);
+
+        //  enable end date, set default date and min date
+        $("#dueDate").datepicker("option", {
+            defaultDate: defaultDue,
+        });
+    }
+});
+
+//  click handler for autofill button
+$("#autofillButton").click( function() {
+    //  variables
+    var currentStart = $("#startDate").datepicker("getDate");
+    var defaultEnd = new Date(currentStart);
+    var defaultDue = new Date(currentStart);
+
+    //  calculate default dates for end and due dates
+    defaultEnd.setDate(currentStart.getDate() + 76);
+    defaultDue.setDate(currentStart.getDate() - 7);
+
+    //  enable end date, set default date and min date
+    if (!dateIsValid($("#endDate").val())) {
+        $("#endDate").datepicker("option", {
+            defaultDate: defaultEnd
+        });
+        $("#endDate").val(defaultEnd.toPaddedLocaleDateString());
+    }
+    //enable due date, set default date and max date
+    if (!dateIsValid($("#dueDate").val())) {
+        $("#dueDate").datepicker("option", {
+            defaultDate: defaultDue
+        });
+        $("#dueDate").val(defaultDue.toPaddedLocaleDateString());
+    }
+ 
+    //  update objects
+    $("#endDate").trigger("change");
+    $("#dueDate").trigger("change");
+    updateInfo();
+    validateInput();
+});
+
+//  click handler for reset button
+$("#resetButton").click( function() {
+    $("#endDate").prop("disabled", true);
+    $("#dueDate").prop("disabled", true);
+    $("#nameGroup").removeClass("has-success");
+    $("#nameGroup").addClass("has-error");
+    $("#startGroup").removeClass("has-success");
+    $("#startGroup").addClass("has-error");
+    $("#endGroup").removeClass("has-success");
+    $("#endGroup").addClass("has-error");
+    $("#dueGroup").removeClass("has-success");
+    $("#dueGroup").addClass("has-error");
+    $("#submitButton").prop("disabled", true);
+    $("#autofillButton").prop("disabled", true);
+    $("#statsDueToStart").text("Due Date: UNKNOWN");
+    $("#termDuration").hide();
+    $("#dueOffset").hide();
+    $("#termInfoWarning").show();
 });

--- a/Source/Pages/Admin/create_term.phtml
+++ b/Source/Pages/Admin/create_term.phtml
@@ -1,13 +1,7 @@
 <?php
-//error_reporting(E_ALL);
-//ini_set('display_errors', 'on');
-
 require_once dirname(__FILE__) . "/../../Query/Term.php";
 require_once dirname(__FILE__) . "/../../API/Utility.php";
-
-$report = "";
 ?>
-
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -32,11 +26,23 @@ $report = "";
 
             //  Database connection
             if (!($CONNECTION = @fido_db_connect())) {?>
-                <div class="alert alert-danger text-center" role="alert"><strong>FAILURE!</strong><br>ERROR: unable to connect to database</div><?php
+                <div class="alert alert-danger text-center" role="alert">
+                    <strong>FAILURE!</strong>
+                    <br>
+                    ERROR: unable to connect to database
+                </div><?php
             } else if (!@add_term($name, $start, $end, $due)) {?>
-                <div class="alert alert-danger text-center" role="alert"><strong>FAILURE!</strong><br><?php echo pg_last_error();?></div><?php
+                <div class="alert alert-danger text-center" role="alert">
+                    <strong>FAILURE!</strong>
+                    <br>
+                    <?php echo pg_last_error();?>
+                </div><?php
             } else {?>
-                <div class="alert alert-success text-center" role="alert"><strong>SUCCESS!</strong><br><?php echo $name; ?> added to FIDO system</div><?php
+                <div class="alert alert-success text-center" role="alert">
+                    <strong>SUCCESS!</strong>
+                    <br>
+                    <?php echo $name; ?> added to FIDO system
+                </div><?php
             }
         }
         ?>
@@ -51,7 +57,7 @@ $report = "";
                             <div class="form-group has-error" id="nameGroup"> <!--  begin term name form group  -->
                                 <div class="input-group">  <!--  begin term name input group  -->
                                     <span class="input-group-addon" id="termNameAddon">Term Name</span>
-                                    <input class="form-control" type="text" id="termName" name="termName" maxlength="100" placeholder="Name of term" aria-describedby="termNameAddon" />
+                                    <input class="form-control" type="text" id="termName" name="termName" maxlength="20" placeholder="Name of term" aria-describedby="termNameAddon" />
                                     <span class="input-group-btn">
                                         <button class="btn btn-danger" type="button" id="termNameClear">Clear</button>
                                     </span>

--- a/Source/Pages/Admin/create_term.phtml
+++ b/Source/Pages/Admin/create_term.phtml
@@ -13,6 +13,7 @@ $report = "";
     <meta charset="utf-8">
     <title>Create New Term</title>
     <link rel="stylesheet" href="../../JQuery-1.2/UI/jquery-ui-darkness/jquery-ui.min.css">
+    <link rel="stylesheet" href="../../css/bootstrap_current/css/bootstrap.min.css">
     <script src="../../JQuery-1.2/jquery-1.12.4.js"></script>
     <script src="../../JQuery-1.2/UI/jquery-ui-darkness/jquery-ui.min.js"></script>
     <script src="../../JavaScript/Admin/create_term.js"></script>
@@ -22,40 +23,48 @@ $report = "";
 </head>
 
 <body>
-    <a href="../login_home.php">Return Home</a><br><br>
-    <form action="<?php echo htmlentities($_SERVER['PHP_SELF']); ?>" method="POST">
-        <label for="termName">Term Name:</label><br>
-        <input type="text" id="termName" class="invalidInput" name="termName" /><br>
-        <label for="startDate">Start Date:</label><br>
-        <input type="text" id="startDate" class="invalidInput" name="startDate" readonly="true"><br>
-        <label for="endDate">End Date:</label><br>
-        <input type="text" id="endDate" class="invalidInput" name="endDate" readonly="true" disabled="true"><br>
-        <label for="dueDate">Due Date:</label><br>
-        <input type="text" id="dueDate" class="invalidInput" name="dueDate" readonly="true" disabled="true"><br>
-        <p id="statsStartToEnd">Term Duration: UNKNOWN</p>
-        <p id="statsDueToStart">Due Date: UNKNOWN</p>
-        <!-- <input type="submit" name="submit" value="Create Term" /> -->
-        <button type="submit" id="submitButton" name="submit" disabled="true">Submit</button>
-        <button type="reset" id="resetButton">Clear</button>
-    </form>
-<?php
-//  check for submission
-if (isset($_POST['submit'])) {
-    $name = $_POST['termName'];
-    $start = new DateTime($_POST['startDate']);
-    $end = new DateTime($_POST['endDate']);
-    $due = new DateTime($_POST['dueDate']);
+    <div class="container">
+        <a class="btn btn-primary" href="../login_home.php">Return Home</a><br><br>
+        <form action="<?php echo htmlentities($_SERVER['PHP_SELF']); ?>" method="POST">
+            <div class="panel panel-default">
+                <div class="panel panel-heading">
+                    <h2 class="panel-title">New Term</h2>
+                </div>
+                <div class="panel-body">
+                    <label for="termName">Term Name:</label><br>
+                    <input type="text" id="termName" class="invalidInput" name="termName" /><br><br>
+                    <label for="startDate">Start Date:</label><br>
+                    <input type="text" id="startDate" class="invalidInput" name="startDate" readonly="true"><br><br>
+                    <label for="endDate">End Date:</label><br>
+                    <input type="text" id="endDate" class="invalidInput" name="endDate" readonly="true" disabled="true"><br><br>
+                    <label for="dueDate">Due Date:</label><br>
+                    <input type="text" id="dueDate" class="invalidInput" name="dueDate" readonly="true" disabled="true"><br><br><br>
+                    <p id="statsStartToEnd">Term Duration: UNKNOWN</p>
+                    <p id="statsDueToStart">Due Date: UNKNOWN</p>
+                </div>
+            </div>
+            <button class="btn btn-primary" type="submit" id="submitButton" name="submit" disabled="true">Submit</button>
+            <button class="btn btn-primary" type="reset" id="resetButton">Clear</button>
+        </form>
+    <?php
+    //  check for submission
+    if (isset($_POST['submit'])) {
+        $name = $_POST['termName'];
+        $start = new DateTime($_POST['startDate']);
+        $end = new DateTime($_POST['endDate']);
+        $due = new DateTime($_POST['dueDate']);
 
-    //  Database connection
-    if (!($CONNECTION = fido_db_connect())) {
-        $report = "ERROR: Failed to connect to database";
-    } else if (!add_term($name, $start, $end, $due)) {
-        $report = "ERROR: Failed to add term to database";
-    } else {
-        $report = "Term Created";
+        //  Database connection
+        if (!($CONNECTION = fido_db_connect())) {
+            $report = "ERROR: Failed to connect to database";
+        } else if (!add_term($name, $start, $end, $due)) {
+            $report = "ERROR: Failed to add term to database";
+        } else {
+            $report = "Term Created";
+        }
     }
-}
-?>
+    ?>
     <p><?php echo $report; ?></p>
+    </div>
 </body>
 </html>

--- a/Source/Pages/Admin/create_term.phtml
+++ b/Source/Pages/Admin/create_term.phtml
@@ -1,6 +1,6 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 'on');
+//error_reporting(E_ALL);
+//ini_set('display_errors', 'on');
 
 require_once dirname(__FILE__) . "/../../Query/Term.php";
 require_once dirname(__FILE__) . "/../../API/Utility.php";
@@ -14,57 +14,113 @@ $report = "";
     <title>Create New Term</title>
     <link rel="stylesheet" href="../../JQuery-1.2/UI/jquery-ui-darkness/jquery-ui.min.css">
     <link rel="stylesheet" href="../../css/bootstrap_current/css/bootstrap.min.css">
-    <script src="../../JQuery-1.2/jquery-1.12.4.js"></script>
-    <script src="../../JQuery-1.2/UI/jquery-ui-darkness/jquery-ui.min.js"></script>
-    <script src="../../JavaScript/Admin/create_term.js"></script>
     <style type="text/css">
-        .invalidInput { border: 2px solid red; }
+        .input-group-addon { min-width: 100px; }
     </style>
 </head>
 
 <body>
-    <div class="container">
-        <a class="btn btn-primary" href="../login_home.php">Return Home</a><br><br>
-        <form action="<?php echo htmlentities($_SERVER['PHP_SELF']); ?>" method="POST">
-            <div class="panel panel-default">
-                <div class="panel panel-heading">
-                    <h2 class="panel-title">New Term</h2>
-                </div>
-                <div class="panel-body">
-                    <label for="termName">Term Name:</label><br>
-                    <input type="text" id="termName" class="invalidInput" name="termName" /><br><br>
-                    <label for="startDate">Start Date:</label><br>
-                    <input type="text" id="startDate" class="invalidInput" name="startDate" readonly="true"><br><br>
-                    <label for="endDate">End Date:</label><br>
-                    <input type="text" id="endDate" class="invalidInput" name="endDate" readonly="true" disabled="true"><br><br>
-                    <label for="dueDate">Due Date:</label><br>
-                    <input type="text" id="dueDate" class="invalidInput" name="dueDate" readonly="true" disabled="true"><br><br><br>
-                    <p id="statsStartToEnd">Term Duration: UNKNOWN</p>
-                    <p id="statsDueToStart">Due Date: UNKNOWN</p>
-                </div>
-            </div>
-            <button class="btn btn-primary" type="submit" id="submitButton" name="submit" disabled="true">Submit</button>
-            <button class="btn btn-primary" type="reset" id="resetButton">Clear</button>
-        </form>
-    <?php
-    //  check for submission
-    if (isset($_POST['submit'])) {
-        $name = $_POST['termName'];
-        $start = new DateTime($_POST['startDate']);
-        $end = new DateTime($_POST['endDate']);
-        $due = new DateTime($_POST['dueDate']);
+    <br>
+    <div class="container"> <!-- begin container -->
+        <?php
+        //  check for submission
+        if (isset($_POST['submit'])) {
+            $name = $_POST['termName'];
+            $start = new DateTime($_POST['startDate']);
+            $end = new DateTime($_POST['endDate']);
+            $due = new DateTime($_POST['dueDate']);
 
-        //  Database connection
-        if (!($CONNECTION = fido_db_connect())) {
-            $report = "ERROR: Failed to connect to database";
-        } else if (!add_term($name, $start, $end, $due)) {
-            $report = "ERROR: Failed to add term to database";
-        } else {
-            $report = "Term Created";
+            //  Database connection
+            if (!($CONNECTION = @fido_db_connect())) {?>
+                <div class="alert alert-danger text-center" role="alert"><strong>FAILURE!</strong><br>ERROR: unable to connect to database</div><?php
+            } else if (!@add_term($name, $start, $end, $due)) {?>
+                <div class="alert alert-danger text-center" role="alert"><strong>FAILURE!</strong><br><?php echo pg_last_error();?></div><?php
+            } else {?>
+                <div class="alert alert-success text-center" role="alert"><strong>SUCCESS!</strong><br><?php echo $name; ?> added to FIDO system</div><?php
+            }
         }
-    }
-    ?>
-    <p><?php echo $report; ?></p>
-    </div>
+        ?>
+        <form id="termForm" action="<?php echo htmlentities($_SERVER['PHP_SELF']); ?>" method="POST">
+            <div class="row"> <!--  begin row 1  -->
+                <div class="col-md-9"> <!--  begin row 1 column 1  -->
+                    <div class="panel panel-primary"> <!--  begin create term panel  -->
+                        <div class="panel panel-heading"> <!--  begin create term panel heading  -->
+                            <h2 class="panel-title">Create Term</h2>
+                        </div> <!--  end create term panel heading  -->
+                        <div class="panel-body"> <!--  begin create term panel body  -->
+                            <div class="form-group has-error" id="nameGroup"> <!--  begin term name form group  -->
+                                <div class="input-group">  <!--  begin term name input group  -->
+                                    <span class="input-group-addon" id="termNameAddon">Term Name</span>
+                                    <input class="form-control" type="text" id="termName" name="termName" maxlength="100" placeholder="Name of term" aria-describedby="termNameAddon" />
+                                    <span class="input-group-btn">
+                                        <button class="btn btn-danger" type="button" id="termNameClear">Clear</button>
+                                    </span>
+                                </div> <!--  end term name input group  -->
+                            </div> <!--  end term name form group  -->
+                            <div class="form-group has-error" id="startGroup"> <!--  begin start date form group  -->
+                                <div class="input-group"> <!--  begin start date input group  -->
+                                    <span class="input-group-addon" id="startDateAddon">Start Date</span>
+                                    <input class="form-control" type="text" id="startDate" name="startDate" readonly="true" placeholder="Starting date" aria-describedby="startDateAddon" />
+                                    <span class="input-group-btn">
+                                        <button class="btn btn-danger" type="button" id="startDateClear">Clear</button>
+                                    </span>
+                                </div> <!--  end start date input group  -->
+                            </div> <!--  end start date form group  -->
+                            <div class="form-group has-error" id="endGroup"> <!--  begin end date form group  -->
+                                <div class="input-group"> <!--  begin end date input group  -->
+                                    <span class="input-group-addon" id="endDateAddon">End Date</span>
+                                    <input class="form-control" type="text" id="endDate" name="endDate" readonly="true" disabled="true" placeholder="Ending date" aria-describedby="endDateAddon" />
+                                    <span class="input-group-btn">
+                                        <button class="btn btn-danger" type="button" id="endDateClear">Clear</button>
+                                    </span>
+                                </div> <!--  end end date input group  -->
+                            </div> <!--  end end date form group  -->
+                            <div class="form-group has-error" id="dueGroup"> <!--  begin due date form group  -->
+                                <div class="input-group"> <!--  begin due date input group  -->
+                                    <span class="input-group-addon" id="dueDateAddon">Due Date</span>
+                                    <input class="form-control" type="text" id="dueDate" name="dueDate" readonly="true" disabled="true" placeholder="Submission deadline" aria-describedby="dueDateAddon" />
+                                    <span class="input-group-btn">
+                                        <button class="btn btn-danger" type="button" id="dueDateClear">Clear</button>
+                                    </span>
+                                </div> <!--  end due date input group  -->
+                            </div> <!--  end due date form group -->
+                            <br><br>
+                        </div> <!--  end create term panel body  -->
+                    </div> <!--  end create term panel  -->
+                </div> <!--  end row 1 column 1  -->
+                <div class="col-md-3"> <!--  begin row 1 column 2  -->
+                    <div class="panel panel-info" id="termInfo"> <!--  begin term info panel  -->
+                        <div class="panel panel-heading"> <!--  begin term info panel heading  -->
+                            <h2 class="panel-title">Term Information</h2>
+                        </div> <!--  end term info panel heading  -->
+                        <div class="panel-body"> <!--  begin term info panel body  -->
+                            <div class="alert alert-warning text-center" role="alert" id="termInfoWarning">
+                                <strong>Not Enough Data</strong>
+                                <br>
+                                Fill out the <mark>start date</mark> and either <mark>end date</mark> or <mark>due date</mark> for term information
+                            </div>
+                            <div class="alert alert-info text-center" role="alert" id="termDuration" hidden>
+                                <strong>Duration:</strong><div id="statsStartToEnd1"></div><div id="statsStartToEnd2"></div>
+                            </div>
+                            <div class="alert alert-info text-center" role="alert" id="dueOffset" hidden>
+                                <strong>Due Date:</strong><div id="statsDueToStart"></div>
+                            </div>
+                        </div> <!--  end term info panel body -->
+                    </div> <!--  end term info panel  -->
+                </div> <!--  end row 1 column 2  -->
+            </div> <!--  end row 1  -->
+            <div class="row"> <!--  begin row 2  -->
+                <div class="col-md-9"> <!--  begin row 2 column 1  -->
+                    <button class="btn btn-primary" type="submit" id="submitButton" name="submit" disabled="true">Submit</button>
+                    <button class="btn btn-primary" type="button" id="autofillButton" disabled="true">Autofill</button>
+                    <button class="btn btn-danger" type="reset" id="resetButton">Reset</button>
+                    <a class="btn btn-primary" href="../login_home.php" style="float: right">Return Home</a>
+                </div> <!--  end row 2 column 1  -->
+            </div> <!--  end row 2  -->
+        </form>
+    </div> <!-- end container -->
 </body>
+<script src="../../JQuery-1.2/jquery-1.12.4.js"></script>
+<script src="../../JQuery-1.2/UI/jquery-ui-darkness/jquery-ui.min.js"></script>
+<script src="../../JavaScript/Admin/create_term.js"></script>
 </html>


### PR DESCRIPTION
**Modified Source:**
- Source/Pages/Admin/create_term.phtml
- Source/JavaScript/Admin/create_term.js

**Changes:**
- Bootstrap integration for create_term.phtml
- Form fields can be cleared individually
- End date and due date autofill now handled by button instead of happening automatically upon changing start date
- Layout of create_term.js modified to no longer require $(document).ready() before executing to improve performance after changes required for bootstrap integration
- HTML script tags for including javascript moved to bottom of create_term.phtml (required by above change)
- Readability improvements for create_term.js (primary for recognizing DOM elements)